### PR TITLE
Some refactors

### DIFF
--- a/lib/ecto_ordered.ex
+++ b/lib/ecto_ordered.ex
@@ -36,7 +36,7 @@ defmodule EctoOrdered do
   alias EctoOrdered, as: Order
 
   defmacro __using__(opts \\ []) do
-    struct = %{repo: repo, field: field, scope: scope, move: move} = build(opts, __CALLER__)
+    struct = %{repo: repo, field: field, move: move} = build(opts, __CALLER__)
     struct = Macro.escape(struct)
 
     quote location: :keep do
@@ -71,81 +71,94 @@ defmodule EctoOrdered do
         %Ecto.Changeset{cs | valid?: true}
       end
 
-      callback_args = [unquote(repo), field, unquote(scope)]
+      callback_args = [unquote(struct)]
 
       before_insert EctoOrdered, :before_insert, callback_args
-      before_update EctoOrdered, :before_update, [unquote(struct)]
-      before_delete EctoOrdered, :before_delete, [unquote(struct)]
+      before_update EctoOrdered, :before_update, callback_args
+      before_delete EctoOrdered, :before_delete, callback_args
     end
   end
 
-  defp build(opts, caller) do
-    unless repo = opts[:repo] do
-      raise ArgumentError, message:
-      "EctoOrdered requires :repo to be specified for " <>
-      "#{inspect caller.module}.#{to_string(opts[:field])}"
-    end
-
-    opts = Keyword.put(opts, :repo, Macro.expand(repo, caller))
-    if field = opts[:field] do
-      opts = [{:move, :"move_#{field}"}|opts]
-    end
-
-    struct(Order, opts)
-  end
-
-  defp update_scope(%Order{scope: scope} = struct, cs) do
-    old_scope = get_change(cs, scope)
-    new_scope = Map.get(cs.model, scope)
-
-    struct
-    |> Map.put(:old_scope, old_scope)
-    |> Map.put(:new_scope, new_scope)
-  end
-
-  def increment_position(module, field, _scope, split_by, nil) do
+  def increment_position(%Order{module: module, field: field, scope: nil, new_position: split_by}) do
     query = from m in module,
             where: field(m, ^field) >= ^split_by
     module.__ecto_ordered__increment__(query)
   end
-  def increment_position(module, field, scope, split_by, new_scope) do
+  def increment_position(%Order{module: module, field: field, scope: scope, new_position: split_by, new_scope: new_scope}) do
     query = from m in module,
             where: field(m, ^field) >= ^split_by and field(m, ^scope) == ^new_scope
     module.__ecto_ordered__increment__(query)
   end
 
-  def decrement_position(module, %Order{field: field, old_position: split_by, until: until, scope: nil}) do
+  def decrement_position(%Order{module: module, field: field, old_position: split_by, until: until, scope: nil}) do
     query = from m in module,
             where: field(m, ^field) > ^split_by and field(m, ^field) <= ^until
     module.__ecto_ordered__decrement__(query)
   end
-  def decrement_position(module, %Order{field: field, scope: scope, old_position: split_by, until: until, new_scope: new_scope}) do
+  def decrement_position(%Order{module: module, field: field, scope: scope, old_position: split_by, until: until, new_scope: new_scope}) do
     query = from m in module,
             where: field(m, ^field) > ^split_by and field(m, ^field) <= ^until
                    and field(m, ^scope) == ^new_scope
     module.__ecto_ordered__decrement__(query)
   end
 
-  defp validate_position!(cs, field, position, max) when position > max + 1 do
+  defp validate_position!(cs, %Order{field: field, new_position: position, max: max}) when position > max + 1 do
     raise EctoOrdered.InvalidMove, type: :too_large
     %Ecto.Changeset{ cs | valid?: false } |> add_error(field, :too_large)
   end
-  defp validate_position!(cs, field, position, _) when position < 1 do
+  defp validate_position!(cs, %Order{field: field, new_position: position}) when position < 1 do
     raise EctoOrdered.InvalidMove, type: :too_small
     %Ecto.Changeset{ cs | valid?: false } |> add_error(field, :too_small)
   end
-  defp validate_position!(cs, _, _, _), do: cs
+  defp validate_position!(cs, _), do: cs
 
-  def before_insert(%{model: %{__struct__: module}} = cs, repo, field, scope) do
-    rows = lock_table(cs, scope, field) |> repo.all
+  defp build(opts, caller) do
+    module = caller.module
+    unless repo = opts[:repo] do
+      raise ArgumentError, message:
+      "EctoOrdered requires :repo to be specified for " <>
+      "#{inspect module}.#{to_string(opts[:field])}"
+    end
+
+    if field = opts[:field] do
+      opts = [{:move, :"move_#{field}"}|opts]
+    end
+
+    %{struct(Order, opts)|repo: Macro.expand(repo, caller), module: module}
+  end
+
+  defp update_old_scope(%Order{scope: scope} = struct, cs) do
+    %{struct|old_scope: get_change(cs, scope)}
+  end
+
+  defp update_new_scope(%Order{scope: scope} = struct, cs) do
+    %{struct|new_scope: Map.get(cs.model, scope)}
+  end
+
+  defp update_new_position(%Order{field: field} = struct, cs) do
+    %{struct|new_position: get_change(cs, field)}
+  end
+
+  defp update_old_position(%Order{field: field} = struct, cs) do
+    %{struct|old_position: Map.get(cs.model, field)}
+  end
+
+  defp update_max(%Order{repo: repo} = struct, cs) do
+    rows = lock_table(struct, cs) |> repo.all
     max = (rows == [] && 0) || Enum.max(rows)
+    %{struct|max: max}
+  end
+
+  def before_insert(cs, %Order{field: field} = struct) do
+    struct = %Order{max: max} = update_max(struct, cs)
     position_assigned = get_field(cs, field)
 
     if position_assigned do
-      new_position = get_change(cs, field)
-      new_scope = get_field(cs, scope)
-      increment_position(module, field, scope, new_position, new_scope)
-      validate_position!(cs, field, new_position, max)
+      struct = struct
+               |> update_new_scope(cs)
+               |> update_new_position(cs)
+      increment_position(struct)
+      validate_position!(cs, struct)
     else
       put_change(cs, field, max + 1)
     end
@@ -153,70 +166,61 @@ defmodule EctoOrdered do
 
   def before_update(cs, struct) do
     struct
-    |> update_scope(cs)
+    |> update_old_scope(cs)
+    |> update_new_scope(cs)
     |> reorder_model(cs)
   end
 
-  defp reorder_model(%Order{repo: repo, field: field, scope: scope, old_scope: old_scope, new_scope: new_scope} = struct, cs)
+  defp reorder_model(%Order{scope: scope, old_scope: old_scope, new_scope: new_scope} = struct, cs)
       when not is_nil(old_scope) and new_scope != old_scope do
     cs
     |> put_change(scope, new_scope)
     |> before_delete(struct)
-    before_insert(cs, repo, field, scope)
+    before_insert(cs, struct)
   end
-  defp reorder_model(%Order{repo: repo, field: field, scope: scope} = struct, cs) do
-    rows = lock_table(cs, scope, field) |> repo.all
-    max = (rows == [] && 0) || Enum.max(rows)
-    new_position = get_change(cs, field)
-    old_position = Map.get(cs.model, field)
-
-    struct = %{struct | old_position: old_position, new_position: new_position, max: max}
-    adjust_position(struct, cs)
+  defp reorder_model(struct, cs) do
+    struct
+    |> update_max(cs)
+    |> update_new_position(cs)
+    |> update_old_position(cs)
+    |> adjust_position(cs)
   end
 
   defp adjust_position(%Order{max: max, field: field, new_position: new_position, old_position: old_position} = struct, cs)
       when new_position > old_position do
-    module = cs.model.__struct__
     struct = %{struct|until: new_position}
 
-    decrement_position(module, struct)
+    decrement_position(struct)
     cs = if new_position == max + 1, do: put_change(cs, field, max), else: cs
-    validate_position!(cs, field, new_position, max)
+    validate_position!(cs, struct)
   end
-  defp adjust_position(%Order{max: max, field: field, scope: scope, new_position: new_position, old_position: old_position} = struct, cs)
+  defp adjust_position(%Order{max: max, new_position: new_position, old_position: old_position} = struct, cs)
       when new_position < old_position do
-    new_scope = get_field(cs, scope)
-    module = cs.model.__struct__
     struct = %{struct|until: max}
 
-    decrement_position(module, struct)
-    increment_position(module, field, scope, new_position, new_scope)
-    validate_position!(cs, field, new_position, max)
+    decrement_position(struct)
+    increment_position(struct)
+    validate_position!(cs, struct)
   end
   defp adjust_position(_struct, cs) do
     cs
   end
 
-  def before_delete(cs, %Order{repo: repo, field: field, scope: scope} = struct) do
-    rows = lock_table(cs, scope, field) |> repo.all
-    max = (rows == [] && 0) || Enum.max(rows)
-    old_position = Map.get(cs.model, field)
-    new_scope = get_field(cs, scope)
-    struct = %{struct|until: max, old_position: old_position, new_scope: new_scope}
-
-    decrement_position(cs.model.__struct__, struct)
+  def before_delete(cs, struct) do
+    struct = %Order{max: max} = struct
+                                |> update_max(cs)
+                                |> update_old_position(cs)
+                                |> update_new_scope(cs)
+    decrement_position(%{struct|until: max})
     cs
   end
 
-  defp lock_table(%{model: %{__struct__: module}}, nil, field) do
-    q = from m in module, lock: "FOR UPDATE"
-    select(q, field)
+  defp lock_table(%Order{module: module, field: field, scope: nil}, _cs) do
+    from(m in module, lock: "FOR UPDATE") |> select(field)
   end
-  defp lock_table(%{model: %{__struct__: module}} = cs, scope, _field) do
-    q = from m in module, lock: "FOR UPDATE"
-
+  defp lock_table(%Order{module: module, field: field, scope: scope}, cs) do
     new_scope = get_field(cs, scope)
-    scope_query(q, field, scope, new_scope)
+    from(m in module, lock: "FOR UPDATE") |> scope_query(field, scope, new_scope)
   end
 
   defp select(q, field) do

--- a/lib/ecto_ordered.ex
+++ b/lib/ecto_ordered.ex
@@ -47,55 +47,39 @@ defmodule EctoOrdered do
         [{unquote(field), fragment("? - 1", m.unquote(field))}])
       end
 
-      if unquote(scope) do
-        def __ecto_ordered__increment_position_query__(split_by, nil) do
-          query = Query.from m in __MODULE__,
-                  where: m.unquote(field) >= ^split_by and is_nil(m.unquote(scope))
-          __ecto_ordered__increment__(query)
-        end
+      def __ecto_ordered__increment_position_query__(split_by, nil) do
+        query = Query.from m in __MODULE__,
+                where: m.unquote(field) >= ^split_by
+        __ecto_ordered__increment__(query)
+      end
+      def __ecto_ordered__increment_position_query__(split_by, scope) do
+        query = Query.from m in __MODULE__,
+                where: m.unquote(field) >= ^split_by and m.unquote(scope) == ^scope
+        __ecto_ordered__increment__(query)
+      end
 
-        def __ecto_ordered__increment_position_query__(split_by, scope) do
-          query = Query.from m in __MODULE__,
-                  where: m.unquote(field) >= ^split_by and m.unquote(scope) == ^scope
-          __ecto_ordered__increment__(query)
-        end
+      def __ecto_ordered__decrement_position_query__(split_by, until, nil) do
+        query = Query.from m in __MODULE__,
+                where: m.unquote(field) > ^split_by and m.unquote(field) <= ^until
+        __ecto_ordered__decrement__(query)
+      end
+      def __ecto_ordered__decrement_position_query__(split_by, until, scope) do
+        query = Query.from m in __MODULE__,
+                where: m.unquote(field) > ^split_by and m.unquote(field) <= ^until
+                       and m.unquote(scope) == ^scope
+        __ecto_ordered__decrement__(query)
+      end
 
-        def __ecto_ordered__decrement_position_query__(split_by, until, nil) do
-          query = Query.from m in __MODULE__,
-                  where: m.unquote(field) > ^split_by and m.unquote(field) <= ^until
-                         and is_nil(m.unquote(scope))
-          __ecto_ordered__decrement__(query)
-        end
+      def __ecto_ordered__scope_query__(q, scope) do
+        q
+        |> EctoOrdered.select(unquote(field))
+        |> Query.where([m], m.unquote(scope) == ^scope)
+      end
 
-        def __ecto_ordered__decrement_position_query__(split_by, until, scope) do
-          query = Query.from(m in __MODULE__,
-                  where: m.unquote(field) > ^split_by and m.unquote(field) <= ^until
-                         and m.unquote(scope) == ^scope)
-          __ecto_ordered__decrement__(query)
-        end
-
-        def __ecto_ordered__scope_query__(q, scope) do
-          q
-          |> EctoOrdered.select(unquote(field))
-          |> Query.where([m], m.unquote(scope) == ^scope)
-        end
-
-        def __ecto_ordered__scope_nil_query__(q) do
-          q
-          |> EctoOrdered.select(unquote(field))
-          |> Query.where([m], is_nil(m.unquote(scope)))
-        end
-      else
-        def __ecto_ordered__increment_position_query__(split_by, _scope) do
-          query = Query.from(m in __MODULE__, where: m.unquote(field) >= ^split_by)
-          __ecto_ordered__increment__(query)
-        end
-
-        def __ecto_ordered__decrement_position_query__(split_by, until, _scope) do
-          query = Query.from(m in __MODULE__, where: m.unquote(field) > ^split_by
-                                  and m.unquote(field) <= ^until)
-          __ecto_ordered__decrement__(query)
-        end
+      def __ecto_ordered__scope_nil_query__(q) do
+        q
+        |> EctoOrdered.select(unquote(field))
+        |> Query.where([m], is_nil(m.unquote(scope)))
       end
 
       @doc """

--- a/test/ecto_ordered_test.exs
+++ b/test/ecto_ordered_test.exs
@@ -294,6 +294,4 @@ defmodule EctoOrderedTest.Scoped do
     assert Repo.get(Model, model4.id).scoped_position == 3
     assert Repo.get(Model, model5.id).scoped_position == 4
   end
-
-
 end

--- a/test/ecto_ordered_test.exs
+++ b/test/ecto_ordered_test.exs
@@ -277,7 +277,6 @@ defmodule EctoOrderedTest.Scoped do
     assert Repo.get(Model, model2.id).scope == 2
   end
 
-
   ## Deletion
 
   test "scoped: deleting an item" do
@@ -293,5 +292,12 @@ defmodule EctoOrderedTest.Scoped do
     assert Repo.get(Model, model3.id).scoped_position == 2
     assert Repo.get(Model, model4.id).scoped_position == 3
     assert Repo.get(Model, model5.id).scoped_position == 4
+  end
+
+  ## Building struct
+
+  test "build/1" do
+    struct = EctoOrdered.build([repo: Repo], %Macro.Env{module: Model})
+    assert struct == %EctoOrdered{repo: FullRepo}
   end
 end

--- a/test/ecto_ordered_test.exs
+++ b/test/ecto_ordered_test.exs
@@ -293,11 +293,4 @@ defmodule EctoOrderedTest.Scoped do
     assert Repo.get(Model, model4.id).scoped_position == 3
     assert Repo.get(Model, model5.id).scoped_position == 4
   end
-
-  ## Building struct
-
-  test "build/1" do
-    struct = EctoOrdered.build([repo: Repo], %Macro.Env{module: Model})
-    assert struct == %EctoOrdered{repo: FullRepo}
-  end
 end


### PR DESCRIPTION
@yrashk I moved the code around with the goal of extracting most of the functions defined inside the `__using__` quote. This way we minimize the numbers of functions defined in the modules that use `EctoOrdered`. Will likely need to define `__ecto_ordered__increment__/1` and `__ecto_ordered__decrement__/1` in the modules that use EctoOrdered though. Looking to use a struct too to lessen the number of args passed around to the callbacks.

This is still a work-in-progress. I will be fixing the conflicts and still be moving some of the code around. 

Let me know what you think, so far. Is the direction I'm heading here okay?
