### PR TITLE
Move from using before_* callbacks to prepare_changes

### DIFF
--- a/lib/ecto_ordered.ex
+++ b/lib/ecto_ordered.ex
@@ -1,15 +1,36 @@
 defmodule EctoOrdered do
   @moduledoc """
-  EctoOrdered is an extension for Ecto models to support ordered model position in a list within
-  a table.
+  EctoOrdered provides changeset methods for updating ordering an ordering column
 
-  In order to use it, `use EctoOrdered` should be included into a model
+  It should be added to your schema like so:
 
-  Following options are accepted:
+  ```
+  defmodule OrderedListItem do
+    use Ecto.Schema
+    import Ecto.Changeset
 
-  * `field` — the field that is used to track the position (:position by default)
-  * `scope` — scoping field (nil by default)
-  * `repo`  - Ecto repository that will be used to find the table to adjust the numbering (required)
+    schema "ordered_list_item" do
+      field :title,            :string
+      field :position,         :integer
+    end
+
+    def changeset(model, params) do
+      model
+      |> cast(params, [:position, :title])
+      |> set_order(:position)
+    end
+
+    def delete(model) do
+      model
+      |> cast(%{}, [])
+      |> Map.put(:action, :delete)
+      |> set_order(:position)
+    end
+  end
+  ```
+
+  Note the `delete` function used to ensure that the remaining items are repositioned on
+  deletion.
 
   """
 
@@ -35,71 +56,84 @@ defmodule EctoOrdered do
   import Ecto.Changeset
   alias EctoOrdered, as: Order
 
-  defmacro __using__(opts \\ []) do
-    struct = %{repo: repo, field: field, move: move} = build(opts, __CALLER__)
-    struct = Macro.escape(struct)
+  @doc """
+  Returns a changeset which will include updates to the other ordered rows
+  within the same transaction as the insertion, deletion or update of this row.
 
-    quote location: :keep do
-      field = unquote(field)
-      require unquote(repo)
-
-      def __ecto_ordered__increment__(query)  do
-        query
-        |> unquote(repo).update_all([inc: [{unquote(field), 1}]])
+  The arguments are as follows:
+  - `changeset` the changeset which is part of the ordered list
+  - `field` the field in which the order should be stored
+  - `scope` the field in which the scope for the order should be stored (optional)
+  """
+  def set_order(changeset, field, scope \\ nil) do
+    prepare_changes(changeset, fn changeset ->
+      case changeset.action do
+        :insert -> EctoOrdered.before_insert changeset, %EctoOrdered{repo: changeset.repo,
+                                                                    field: field,
+                                                                    scope: scope}
+        :update -> EctoOrdered.before_update changeset, %EctoOrdered{repo: changeset.repo,
+                                                                    field: field,
+                                                                    scope: scope}
+        :delete -> EctoOrdered.before_delete changeset, %EctoOrdered{repo: changeset.repo,
+                                                                    field: field,
+                                                                    scope: scope}
       end
+    end)
+  end
 
-      def __ecto_ordered__decrement__(query)  do
-        query
-        |> unquote(repo).update_all([inc: [{unquote(field), -1}]])
-      end
+  def before_insert(cs, %Order{field: field} = struct) do
+    struct = %{struct|module: cs.model.__struct__}
+    struct = %Order{max: max} = update_max(struct, cs)
+    position_assigned = get_field(cs, field)
 
-      @doc """
-      Creates a changeset for adjusting the #{field} field
-      """
-      def changeset(model, unquote(move)) do
-        changeset(model, unquote(move), nil)
-      end
-      def changeset(model, unquote(move), params) do
-        cast(params, model, [unquote(field)], [])
-      end
-
-      @doc """
-      Creates a changeset with an adjusted #{field} field
-      """
-      def unquote(move)(model, new_position) do
-        cs = change(model, [{unquote(field), new_position}])
-        %Ecto.Changeset{cs | valid?: true}
-      end
-
-      callback_args = [unquote(struct)]
-
-      before_insert EctoOrdered, :before_insert, callback_args
-      before_update EctoOrdered, :before_update, callback_args
-      before_delete EctoOrdered, :before_delete, callback_args
+    if position_assigned do
+      struct = struct
+      |> update_new_scope(cs)
+      |> update_new_position(cs)
+      increment_position(struct)
+      validate_position!(cs, struct)
+    else
+      put_change(cs, field, max + 1)
     end
   end
 
-  def increment_position(%Order{module: module, field: field, scope: nil, new_position: split_by}) do
-    query = from m in module,
-            where: field(m, ^field) >= ^split_by
-    module.__ecto_ordered__increment__(query)
-  end
-  def increment_position(%Order{module: module, field: field, scope: scope, new_position: split_by, new_scope: new_scope}) do
-    query = from m in module,
-            where: field(m, ^field) >= ^split_by and field(m, ^scope) == ^new_scope
-    module.__ecto_ordered__increment__(query)
+  def before_update(cs, struct) do
+    %{struct|module: cs.model.__struct__}
+    |> update_old_scope(cs)
+    |> update_new_scope(cs)
+    |> reorder_model(cs)
   end
 
-  def decrement_position(%Order{module: module, field: field, old_position: split_by, until: until, scope: nil}) do
+  defp increment_position(%Order{module: module, field: field, scope: nil, new_position: split_by} = struct) do
     query = from m in module,
-            where: field(m, ^field) > ^split_by and field(m, ^field) <= ^until
-    module.__ecto_ordered__decrement__(query)
+            where: field(m, ^field) >= ^split_by
+    execute_increment(struct, query)
   end
-  def decrement_position(%Order{module: module, field: field, scope: scope, old_position: split_by, until: until, new_scope: new_scope}) do
+
+  defp increment_position(%Order{module: module, field: field, scope: scope, new_position: split_by, new_scope: new_scope} = struct) do
+    query = from m in module,
+            where: field(m, ^field) >= ^split_by and field(m, ^scope) == ^new_scope
+    execute_increment(struct, query)
+  end
+
+  defp decrement_position(%Order{module: module, field: field, old_position: split_by, until: until, scope: nil} = struct) do
     query = from m in module,
             where: field(m, ^field) > ^split_by and field(m, ^field) <= ^until
-                   and field(m, ^scope) == ^new_scope
-    module.__ecto_ordered__decrement__(query)
+    execute_decrement(struct, query)
+  end
+
+  defp decrement_position(%Order{module: module, field: field, old_position: split_by, until: nil, old_scope: old_scope, scope: scope} = struct) do
+    query = from m in module,
+    where: field(m, ^field) > ^split_by
+    and field(m, ^scope) == ^old_scope
+    execute_decrement(struct, query)
+  end
+
+  defp decrement_position(%Order{module: module, field: field, scope: scope, old_position: split_by, until: until, old_scope: old_scope} = struct) do
+    query = from m in module,
+    where: field(m, ^field) > ^split_by and field(m, ^field) <= ^until
+            and field(m, ^scope) == ^old_scope
+    execute_decrement(struct, query)
   end
 
   defp validate_position!(cs, %Order{field: field, new_position: position, max: max}) when position > max + 1 do
@@ -112,31 +146,16 @@ defmodule EctoOrdered do
   end
   defp validate_position!(cs, _), do: cs
 
-  defp build(opts, caller) do
-    module = caller.module
-    unless repo = opts[:repo] do
-      raise ArgumentError, message:
-      "EctoOrdered requires :repo to be specified for " <>
-      "#{inspect module}.#{to_string(opts[:field])}"
-    end
-
-    if field = opts[:field] do
-      opts = [{:move, :"move_#{field}"}|opts]
-    end
-
-    %{struct(Order, opts)|repo: Macro.expand(repo, caller), module: module}
-  end
-
   defp update_old_scope(%Order{scope: scope} = struct, cs) do
-    %{struct|old_scope: get_change(cs, scope)}
+    %{struct|old_scope: Map.get(cs.model, scope)}
   end
 
   defp update_new_scope(%Order{scope: scope} = struct, cs) do
-    %{struct|new_scope: Map.get(cs.model, scope)}
+    %{struct|new_scope: get_field(cs, scope)}
   end
 
   defp update_new_position(%Order{field: field} = struct, cs) do
-    %{struct|new_position: get_change(cs, field)}
+    %{struct|new_position: get_field(cs, field)}
   end
 
   defp update_old_position(%Order{field: field} = struct, cs) do
@@ -144,38 +163,18 @@ defmodule EctoOrdered do
   end
 
   defp update_max(%Order{repo: repo} = struct, cs) do
-    rows = lock_table(struct, cs) |> repo.all
+    rows = query(struct, cs) |> repo.all
     max = (rows == [] && 0) || Enum.max(rows)
     %{struct|max: max}
   end
 
-  def before_insert(cs, %Order{field: field} = struct) do
-    struct = %Order{max: max} = update_max(struct, cs)
-    position_assigned = get_field(cs, field)
-
-    if position_assigned do
-      struct = struct
-               |> update_new_scope(cs)
-               |> update_new_position(cs)
-      increment_position(struct)
-      validate_position!(cs, struct)
-    else
-      put_change(cs, field, max + 1)
-    end
-  end
-
-  def before_update(cs, struct) do
-    struct
-    |> update_old_scope(cs)
-    |> update_new_scope(cs)
-    |> reorder_model(cs)
-  end
 
   defp reorder_model(%Order{scope: scope, old_scope: old_scope, new_scope: new_scope} = struct, cs)
       when not is_nil(old_scope) and new_scope != old_scope do
     cs
     |> put_change(scope, new_scope)
     |> before_delete(struct)
+
     before_insert(cs, struct)
   end
   defp reorder_model(struct, cs) do
@@ -202,29 +201,40 @@ defmodule EctoOrdered do
     increment_position(struct)
     validate_position!(cs, struct)
   end
+
   defp adjust_position(_struct, cs) do
     cs
   end
 
   def before_delete(cs, struct) do
-    struct = %Order{max: max} = struct
+    struct = %Order{max: max} = %{struct | module: cs.model.__struct__}
                                 |> update_max(cs)
                                 |> update_old_position(cs)
-                                |> update_new_scope(cs)
+                                |> update_old_scope(cs)
     decrement_position(%{struct|until: max})
     cs
   end
 
-  defp lock_table(%Order{module: module, field: field, scope: nil}, _cs) do
-    from(m in module, lock: "FOR UPDATE") |> selector(field)
+  defp query(%Order{module: module, field: field, scope: nil}, _cs) do
+    from(m in module) |> selector(field)
   end
-  defp lock_table(%Order{module: module, field: field, scope: scope}, cs) do
-    new_scope = get_field(cs, scope)
-    from(m in module, lock: "FOR UPDATE") |> scope_query(field, scope, new_scope)
+
+  defp query(%Order{module: module, field: field, scope: scope}, cs) do
+     new_scope = get_field(cs, scope)
+     scope_query(module, field, scope, new_scope)
   end
 
   defp selector(q, field) do
     Ecto.Query.select(q, [m], field(m, ^field))
+  end
+
+  defp execute_increment(%Order{repo: repo, field: field}, query) do
+    query
+    |> repo.update_all([inc: [{field, 1}]])
+  end
+
+  defp execute_decrement(%Order{repo: repo, field: field}, query) do
+    query |> repo.update_all([inc: [{field, -1}]])
   end
 
   defp scope_query(q, field, scope, nil) do

--- a/lib/ecto_ordered.ex
+++ b/lib/ecto_ordered.ex
@@ -81,6 +81,7 @@ defmodule EctoOrdered do
     end)
   end
 
+  @doc false
   def before_insert(cs, %Order{field: field} = struct) do
     struct = %{struct|module: cs.model.__struct__}
     struct = %Order{max: max} = update_max(struct, cs)
@@ -97,6 +98,7 @@ defmodule EctoOrdered do
     end
   end
 
+  @doc false
   def before_update(cs, struct) do
     %{struct|module: cs.model.__struct__}
     |> update_old_scope(cs)
@@ -206,6 +208,7 @@ defmodule EctoOrdered do
     cs
   end
 
+  @doc false
   def before_delete(cs, struct) do
     struct = %Order{max: max} = %{struct | module: cs.model.__struct__}
                                 |> update_max(cs)

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule EctoOrdered.Mixfile do
   defp package do
     [
       files: ["lib", "priv", "mix.exs", "README*", "readme*", "LICENSE*", "license*"],
-      contributors: ["Yurii Rashkovskii"],
+      contributors: ["Yurii Rashkovskii", "Andrew Harvey"],
       licenses: ["Apache 2.0"],
       links: %{"GitHub" => "https://github.com/trustatom-oss/ecto-ordered"}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -28,8 +28,8 @@ defmodule EctoOrdered.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-     {:ecto, "~> 0.8.1"},
-     {:postgrex, "~> 0.7.0", only: :test},
+     {:ecto, "~> 1.1"},
+     {:postgrex, "~> 0.11.0", only: :test},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"decimal": {:hex, :decimal, "1.1.0"},
-  "ecto": {:hex, :ecto, "0.8.1"},
-  "poolboy": {:hex, :poolboy, "1.4.2"},
-  "postgrex": {:hex, :postgrex, "0.7.0"}}
+%{"connection": {:hex, :connection, "1.0.2"},
+  "db_connection": {:hex, :db_connection, "0.2.5"},
+  "decimal": {:hex, :decimal, "1.1.2"},
+  "ecto": {:hex, :ecto, "1.1.5"},
+  "poolboy": {:hex, :poolboy, "1.5.1"},
+  "postgrex": {:hex, :postgrex, "0.11.1"}}

--- a/test/ecto_ordered_test.exs
+++ b/test/ecto_ordered_test.exs
@@ -4,12 +4,26 @@ defmodule EctoOrderedTest do
   import Ecto.Query
 
   defmodule Model do
-    use Ecto.Model
-    use EctoOrdered, repo: Repo
+    use Ecto.Schema
+    import Ecto.Changeset
+    import EctoOrdered
 
     schema "model" do
       field :title,            :string
       field :position,         :integer
+    end
+
+    def changeset(model, params) do
+      model
+      |> cast(params, [], [:position, :title])
+      |> set_order(:position)
+    end
+
+    def delete(model) do
+      model
+      |> cast(%{}, [], [])
+      |> Map.put(:action, :delete)
+      |> set_order(:position)
     end
   end
 
@@ -24,7 +38,9 @@ defmodule EctoOrderedTest do
 
   test "inserting item with no position" do
     for i <- 1..10 do
-      model = %Model{title: "item with no position, going to be ##{i}"} |> Repo.insert!
+      model = %Model{}
+      |> Model.changeset(%{title: "item with no position, going to be ##{i}"})
+      |> Repo.insert!
       assert model.position == i
     end
     assert (from m in Model, select: m.position) |> Repo.all == Enum.into(1..10, [])
@@ -32,22 +48,32 @@ defmodule EctoOrderedTest do
 
   test "inserting item with a correct appending position" do
     %Model{title: "item with no position, going to be #1"} |> Repo.insert
-    model = %Model{title: "item #2", position: 2} |> Repo.insert!
+    model = %Model{title: "item #2", position: 2}
+    |> Model.changeset(%{})
+    |> Repo.insert!
     assert model.position == 2
   end
 
   test "inserting item with a gapped position" do
-    %Model{title: "item with no position, going to be #1"} |> Repo.insert
+    %Model{title: "item with no position, going to be #1"}
+    |> Model.changeset(%{})
+    |> Repo.insert
     assert_raise EctoOrdered.InvalidMove, "too large", fn ->
-      %Model{title: "item #10", position: 10} |> Repo.insert
+      %Model{title: "item #10", position: 10}
+      |> Model.changeset(%{})
+      |> Repo.insert!
     end
   end
 
   test "inserting item with an inserting position" do
-    model1 = %Model{title: "item with no position, going to be #1"} |> Repo.insert!
-    model2 = %Model{title: "item with no position, going to be #2"} |> Repo.insert!
-    model3 = %Model{title: "item with no position, going to be #3"} |> Repo.insert!
-    model = %Model{title: "item #2", position: 2} |> Repo.insert!
+    model1 = Model.changeset(%Model{}, %{title: "item with no position, going to be #1"})
+    |> Repo.insert!
+    model2 = Model.changeset(%Model{title: "item with no position, going to be #2"}, %{})
+    |> Repo.insert!
+    model3 = Model.changeset(%Model{title: "item with no position, going to be #3"}, %{})
+    |> Repo.insert!
+    model = Model.changeset(%Model{title: "item #2", position: 2}, %{})
+    |> Repo.insert!
     assert model.position == 2
     assert Repo.get(Model, model1.id).position == 1
     assert Repo.get(Model, model2.id).position == 3
@@ -55,10 +81,14 @@ defmodule EctoOrderedTest do
   end
 
   test "inserting item with an inserting position at #1" do
-    model1 = %Model{title: "item with no position, going to be #1"} |> Repo.insert!
-    model2 = %Model{title: "item with no position, going to be #2"} |> Repo.insert!
-    model3 = %Model{title: "item with no position, going to be #3"} |> Repo.insert!
-    model = %Model{title: "item #1", position: 1} |> Repo.insert!
+    model1 = Model.changeset(%Model{title: "item with no position, going to be #1"}, %{})
+    |> Repo.insert!
+    model2 = Model.changeset(%Model{title: "item with no position, going to be #2"}, %{})
+    |> Repo.insert!
+    model3 = Model.changeset(%Model{title: "item with no position, going to be #3"}, %{})
+    |> Repo.insert!
+    model = Model.changeset(%Model{title: "item #1", position: 1}, %{})
+    |> Repo.insert!
     assert model.position == 1
     assert Repo.get(Model, model1.id).position == 2
     assert Repo.get(Model, model2.id).position == 3
@@ -68,19 +98,21 @@ defmodule EctoOrderedTest do
   ## Moving
 
   test "updating item with the same position" do
-    model = %Model{title: "item with no position"} |> Repo.insert!
-    model1 = %Model{model | title: "item with a position"} |> Repo.update!
+    model = Model.changeset(%Model{title: "item with no position"}, %{})
+    |> Repo.insert!
+    model1 = Model.changeset(%Model{model | title: "item with a position"}, %{})
+    |> Repo.update!
     assert model.position == model1.position
   end
 
   test "replacing an item below" do
-    model1 = %Model{title: "item #1"} |> Repo.insert!
-    model2 = %Model{title: "item #2"} |> Repo.insert!
-    model3 = %Model{title: "item #3"} |> Repo.insert!
-    model4 = %Model{title: "item #4"} |> Repo.insert!
-    model5 = %Model{title: "item #5"} |> Repo.insert!
+    model1 = Model.changeset(%Model{title: "item #1"}, %{}) |> Repo.insert!
+    model2 = Model.changeset(%Model{title: "item #2"}, %{}) |> Repo.insert!
+    model3 = Model.changeset(%Model{title: "item #3"}, %{}) |> Repo.insert!
+    model4 = Model.changeset(%Model{title: "item #4"}, %{}) |> Repo.insert!
+    model5 = Model.changeset(%Model{title: "item #5"}, %{}) |> Repo.insert!
 
-    model2 |> Model.move_position(4) |> Repo.update
+    model2 |> Model.changeset(%{position: 4}) |> Repo.update!
 
     assert Repo.get(Model, model1.id).position == 1
     assert Repo.get(Model, model3.id).position == 2
@@ -90,13 +122,13 @@ defmodule EctoOrderedTest do
   end
 
   test "replacing an item above" do
-    model1 = %Model{title: "item #1"} |> Repo.insert!
-    model2 = %Model{title: "item #2"} |> Repo.insert!
-    model3 = %Model{title: "item #3"} |> Repo.insert!
-    model4 = %Model{title: "item #4"} |> Repo.insert!
-    model5 = %Model{title: "item #5"} |> Repo.insert!
+    model1 = Model.changeset(%Model{title: "item #1"}, %{}) |> Repo.insert!
+    model2 = Model.changeset(%Model{title: "item #2"}, %{}) |> Repo.insert!
+    model3 = Model.changeset(%Model{title: "item #3"}, %{}) |> Repo.insert!
+    model4 = Model.changeset(%Model{title: "item #4"}, %{}) |> Repo.insert!
+    model5 = Model.changeset(%Model{title: "item #5"}, %{}) |> Repo.insert!
 
-    model4 |> Model.move_position(2) |> Repo.update
+    model4 |> Model.changeset(%{position: 2}) |> Repo.update
 
     assert Repo.get(Model, model1.id).position == 1
     assert Repo.get(Model, model4.id).position == 2
@@ -106,11 +138,11 @@ defmodule EctoOrderedTest do
   end
 
   test "updating item with a tail position" do
-    model1 = %Model{title: "item #1"} |> Repo.insert!
-    model2 = %Model{title: "item #2"} |> Repo.insert!
-    model3 = %Model{title: "item #3"} |> Repo.insert!
+    model1 = Model.changeset(%Model{title: "item #1"}, %{}) |> Repo.insert!
+    model2 = Model.changeset(%Model{title: "item #2"}, %{}) |> Repo.insert!
+    model3 = Model.changeset(%Model{title: "item #3"}, %{}) |> Repo.insert!
 
-    model2 |> Model.move_position(4) |> Repo.update
+    model2 |> Model.changeset(%{position: 4}) |> Repo.update!
 
     assert Repo.get(Model, model1.id).position == 1
     assert Repo.get(Model, model3.id).position == 2
@@ -120,13 +152,13 @@ defmodule EctoOrderedTest do
   ## Deletion
 
   test "deleting an item" do
-    model1 = %Model{title: "item #1"} |> Repo.insert!
-    model2 = %Model{title: "item #2"} |> Repo.insert!
-    model3 = %Model{title: "item #3"} |> Repo.insert!
-    model4 = %Model{title: "item #4"} |> Repo.insert!
-    model5 = %Model{title: "item #5"} |> Repo.insert!
+    model1 = Model.changeset(%Model{title: "item #1"}, %{}) |> Repo.insert!
+    model2 = Model.changeset(%Model{title: "item #2"}, %{}) |> Repo.insert!
+    model3 = Model.changeset(%Model{title: "item #3"}, %{}) |> Repo.insert!
+    model4 = Model.changeset(%Model{title: "item #4"}, %{}) |> Repo.insert!
+    model5 = Model.changeset(%Model{title: "item #5"}, %{}) |> Repo.insert!
 
-    model2 |> Repo.delete
+    model2 |> Model.delete |> Repo.delete
 
     assert Repo.get(Model, model1.id).position == 1
     assert Repo.get(Model, model3.id).position == 2
@@ -143,13 +175,27 @@ defmodule EctoOrderedTest.Scoped do
   import Ecto.Query
 
   defmodule Model do
-    use Ecto.Model
-    use EctoOrdered, field: :scoped_position, scope: :scope, repo: Repo
+    use Ecto.Schema
+    import Ecto.Changeset
+    import EctoOrdered
 
     schema "scoped_model" do
       field :title,            :string
       field :scope,            :integer
       field :scoped_position,  :integer
+    end
+
+    def changeset(model, params) do
+      model
+      |> cast(params, [],[:scope, :scoped_position, :title])
+      |> set_order(:scoped_position, :scope)
+    end
+
+    def delete(model) do
+      model
+      |> cast(%{}, [], [])
+      |> Map.put(:action, :delete)
+      |> set_order(:scoped_position, :scope)
     end
   end
 
@@ -160,38 +206,49 @@ defmodule EctoOrderedTest.Scoped do
 
   test "scoped: inserting item with no position" do
     for s <- 1..10, i <- 1..10 do
-      model = %Model{scope: s, title: "item with no position, going to be ##{i}"} |> Repo.insert!
+      model = Model.changeset(%Model{scope: s, title: "no position, going to be ##{i}"}, %{})
+      |> Repo.insert!
       assert model.scoped_position == i
     end
     for s <- 1..10 do
-      assert (from m in Model, select: m.scoped_position, where: m.scope == ^s) |>
-      Repo.all == Enum.into(1..10, [])
+      assert (from m in Model,
+              select: m.scoped_position,
+              order_by: [asc: :id], where: m.scope == ^s) |>
+        Repo.all ==  Enum.into(1..10, [])
     end
 
   end
 
   test "scoped: inserting item with a correct appending position" do
-    %Model{scope: 10, title: "item with no position, going to be #1"} |> Repo.insert
-    %Model{scope: 11, title: "item #2"} |> Repo.insert
+    Model.changeset(%Model{scope: 10, title: "item with no position, going to be #1"}, %{})
+    |> Repo.insert
+    Model.changeset(%Model{scope: 11, title: "item #2"}, %{}) |> Repo.insert
 
-    model = %Model{scope: 10, title: "item #2", scoped_position: 2} |> Repo.insert!
+    model = Model.changeset(%Model{scope: 10, title: "item #2", scoped_position: 2}, %{})
+    |> Repo.insert!
 
     assert model.scoped_position == 2
   end
 
   test "scoped: inserting item with a gapped position" do
-    %Model{scope: 1, title: "item with no position, going to be #1"} |> Repo.insert
+    Model.changeset(%Model{scope: 1, title: "item with no position, going to be #1"}, %{})
+    |> Repo.insert!
     assert_raise EctoOrdered.InvalidMove, "too large", fn ->
-      %Model{scope: 1, title: "item #10", scoped_position: 10} |> Repo.insert
+      Model.changeset(%Model{scope: 1, title: "item #10", scoped_position: 10}, %{})
+      |> Repo.insert
     end
   end
 
   test "scoped: inserting item with an inserting position" do
-    model1 = %Model{scope: 1, title: "item with no position, going to be #1"} |> Repo.insert!
-    model2 = %Model{scope: 1, title: "item with no position, going to be #2"} |> Repo.insert!
-    model3 = %Model{scope: 1, title: "item with no position, going to be #3"} |> Repo.insert!
+    model1 = Model.changeset(%Model{scope: 1, title: "no position, going to be #1"}, %{})
+    |> Repo.insert!
+    model2 = Model.changeset(%Model{scope: 1, title: "no position, going to be #2"}, %{})
+    |> Repo.insert!
+    model3 = Model.changeset(%Model{scope: 1, title: "no position, going to be #3"}, %{})
+    |> Repo.insert!
 
-    model = %Model{scope: 1,  title: "item #2", scoped_position: 2} |> Repo.insert!
+    model = Model.changeset(%Model{scope: 1,  title: "item #2", scoped_position: 2}, %{})
+    |> Repo.insert!
 
     assert model.scoped_position == 2
     assert Repo.get(Model, model1.id).scoped_position == 1
@@ -200,10 +257,15 @@ defmodule EctoOrderedTest.Scoped do
   end
 
   test "scoped: inserting item with an inserting position at #1" do
-    model1 = %Model{scope: 1, title: "item with no position, going to be #1"} |> Repo.insert!
-    model2 = %Model{scope: 1, title: "item with no position, going to be #2"} |> Repo.insert!
-    model3 = %Model{scope: 1, title: "item with no position, going to be #3"} |> Repo.insert!
-    model = %Model{scope: 1, title: "item #1", scoped_position: 1} |> Repo.insert!
+    model1 = Model.changeset(%Model{scope: 1, title: "no position, going to be #1"}, %{})
+    |> Repo.insert!
+    model2 = Model.changeset(%Model{scope: 1, title: "no position, going to be #2"}, %{})
+    |> Repo.insert!
+    model3 = Model.changeset(%Model{scope: 1, title: "no position, going to be #3"}, %{})
+    |> Repo.insert!
+    model  = Model.changeset(%Model{scope: 1, title: "item #1", scoped_position: 1}, %{})
+    |> Repo.insert!
+
     assert model.scoped_position == 1
     assert Repo.get(Model, model1.id).scoped_position == 2
     assert Repo.get(Model, model2.id).scoped_position == 3
@@ -213,19 +275,21 @@ defmodule EctoOrderedTest.Scoped do
   ## Moving
 
   test "scoped: updating item with the same position" do
-    model = %Model{scope: 1, title: "item with no position"} |> Repo.insert!
-    model1 = %Model{model | title: "item with a position", scope: 1} |> Repo.update!
+    model = Model.changeset(%Model{scope: 1, title: "no position"}, %{}) |> Repo.insert!
+
+    model1 = Model.changeset(model, %{title: "item with a position", scope: 1})
+    |> Repo.update!
     assert model.scoped_position == model1.scoped_position
   end
 
   test "scoped: replacing an item below" do
-    model1 = %Model{scope: 1, title: "item #1"} |> Repo.insert!
-    model2 = %Model{scope: 1, title: "item #2"} |> Repo.insert!
-    model3 = %Model{scope: 1, title: "item #3"} |> Repo.insert!
-    model4 = %Model{scope: 1, title: "item #4"} |> Repo.insert!
-    model5 = %Model{scope: 1, title: "item #5"} |> Repo.insert!
+    model1 = Model.changeset(%Model{scope: 1, title: "item #1"}, %{}) |> Repo.insert!
+    model2 = Model.changeset(%Model{scope: 1, title: "item #2"}, %{}) |> Repo.insert!
+    model3 = Model.changeset(%Model{scope: 1, title: "item #3"}, %{}) |> Repo.insert!
+    model4 = Model.changeset(%Model{scope: 1, title: "item #4"}, %{}) |> Repo.insert!
+    model5 = Model.changeset(%Model{scope: 1, title: "item #5"}, %{}) |> Repo.insert!
 
-    model2 |> Model.move_scoped_position(4) |> Repo.update
+    model2 |> Model.changeset(%{scoped_position: 4}) |> Repo.update
 
     assert Repo.get(Model, model1.id).scoped_position == 1
     assert Repo.get(Model, model3.id).scoped_position == 2
@@ -235,13 +299,13 @@ defmodule EctoOrderedTest.Scoped do
   end
 
   test "scoped: replacing an item above" do
-    model1 = %Model{scope: 1, title: "item #1"} |> Repo.insert!
-    model2 = %Model{scope: 1, title: "item #2"} |> Repo.insert!
-    model3 = %Model{scope: 1, title: "item #3"} |> Repo.insert!
-    model4 = %Model{scope: 1, title: "item #4"} |> Repo.insert!
-    model5 = %Model{scope: 1, title: "item #5"} |> Repo.insert!
+    model1 = Model.changeset(%Model{scope: 1, title: "item #1"}, %{}) |> Repo.insert!
+    model2 = Model.changeset(%Model{scope: 1, title: "item #2"}, %{}) |> Repo.insert!
+    model3 = Model.changeset(%Model{scope: 1, title: "item #3"}, %{}) |> Repo.insert!
+    model4 = Model.changeset(%Model{scope: 1, title: "item #4"}, %{}) |> Repo.insert!
+    model5 = Model.changeset(%Model{scope: 1, title: "item #5"}, %{}) |> Repo.insert!
 
-    model4 |> Model.move_scoped_position(2) |> Repo.update
+    model4 |> Model.changeset(%{scoped_position: 2}) |> Repo.update
 
     assert Repo.get(Model, model1.id).scoped_position == 1
     assert Repo.get(Model, model4.id).scoped_position == 2
@@ -251,11 +315,11 @@ defmodule EctoOrderedTest.Scoped do
   end
 
   test "scoped: updating item with a tail position" do
-    model1 = %Model{scope: 1, title: "item #1"} |> Repo.insert!
-    model2 = %Model{scope: 1, title: "item #2"} |> Repo.insert!
-    model3 = %Model{scope: 1, title: "item #3"} |> Repo.insert!
+    model1 = Model.changeset(%Model{scope: 1, title: "item #1"}, %{}) |> Repo.insert!
+    model2 = Model.changeset(%Model{scope: 1, title: "item #2"}, %{}) |> Repo.insert!
+    model3 = Model.changeset(%Model{scope: 1, title: "item #3"}, %{}) |> Repo.insert!
 
-    model2 |> Model.move_scoped_position(4) |> Repo.update
+    model2 |> Model.changeset(%{scoped_position: 4}) |> Repo.update
 
     assert Repo.get(Model, model1.id).scoped_position == 1
     assert Repo.get(Model, model3.id).scoped_position == 2
@@ -263,15 +327,15 @@ defmodule EctoOrderedTest.Scoped do
   end
 
   test "scoped: moving between scopes" do
-    model1 = %Model{scope: 1, title: "item #1"} |> Repo.insert!
-    model2 = %Model{scope: 1, title: "item #2"} |> Repo.insert!
-    model3 = %Model{scope: 1, title: "item #3"} |> Repo.insert!
+    model1 = Model.changeset(%Model{scope: 1, title: "item #1"}, %{}) |> Repo.insert!
+    model2 = Model.changeset(%Model{scope: 1, title: "item #2"}, %{}) |> Repo.insert!
+    model3 = Model.changeset(%Model{scope: 1, title: "item #3"}, %{}) |> Repo.insert!
 
-    xmodel1 = %Model{scope: 2, title: "item #1"} |> Repo.insert!
-    xmodel2 = %Model{scope: 2, title: "item #2"} |> Repo.insert!
-    xmodel3 = %Model{scope: 2, title: "item #3"} |> Repo.insert!
+    xmodel1 = Model.changeset(%Model{scope: 2, title: "item #1"}, %{}) |> Repo.insert!
+    xmodel2 = Model.changeset(%Model{scope: 2, title: "item #2"}, %{}) |> Repo.insert!
+    xmodel3 = Model.changeset(%Model{scope: 2, title: "item #3"}, %{}) |> Repo.insert!
 
-    model2 |> Model.move_scoped_position(4) |> Ecto.Changeset.put_change(:scope, 2) |> Repo.update
+    model2 |> Model.changeset(%{scoped_position: 4, scope: 2}) |> Repo.update
 
     assert Repo.get(Model, model1.id).scoped_position == 1
     assert Repo.get(Model, model1.id).scope == 1
@@ -288,13 +352,13 @@ defmodule EctoOrderedTest.Scoped do
   ## Deletion
 
   test "scoped: deleting an item" do
-    model1 = %Model{title: "item #1", scope: 1} |> Repo.insert!
-    model2 = %Model{title: "item #2", scope: 1} |> Repo.insert!
-    model3 = %Model{title: "item #3", scope: 1} |> Repo.insert!
-    model4 = %Model{title: "item #4", scope: 1} |> Repo.insert!
-    model5 = %Model{title: "item #5", scope: 1} |> Repo.insert!
+    model1 = Model.changeset(%Model{title: "item #1", scope: 1}, %{}) |> Repo.insert!
+    model2 = Model.changeset(%Model{title: "item #2", scope: 1}, %{}) |> Repo.insert!
+    model3 = Model.changeset(%Model{title: "item #3", scope: 1}, %{}) |> Repo.insert!
+    model4 = Model.changeset(%Model{title: "item #4", scope: 1}, %{}) |> Repo.insert!
+    model5 = Model.changeset(%Model{title: "item #5", scope: 1}, %{}) |> Repo.insert!
 
-    model2 |> Repo.delete
+    model2 |> Model.delete |> Repo.delete
 
     assert Repo.get(Model, model1.id).scoped_position == 1
     assert Repo.get(Model, model3.id).scoped_position == 2

--- a/test/ecto_ordered_test.exs
+++ b/test/ecto_ordered_test.exs
@@ -13,13 +13,18 @@ defmodule EctoOrderedTest do
     end
   end
 
+  setup do
+    Ecto.Adapters.SQL.restart_test_transaction(EctoOrderedTest.Repo)
+  end
+
+
   # No scope
 
   ## Inserting
 
   test "inserting item with no position" do
     for i <- 1..10 do
-      model = %Model{title: "item with no position, going to be ##{i}"} |> Repo.insert
+      model = %Model{title: "item with no position, going to be ##{i}"} |> Repo.insert!
       assert model.position == i
     end
     assert (from m in Model, select: m.position) |> Repo.all == Enum.into(1..10, [])
@@ -27,7 +32,7 @@ defmodule EctoOrderedTest do
 
   test "inserting item with a correct appending position" do
     %Model{title: "item with no position, going to be #1"} |> Repo.insert
-    model = %Model{title: "item #2", position: 2} |> Repo.insert
+    model = %Model{title: "item #2", position: 2} |> Repo.insert!
     assert model.position == 2
   end
 
@@ -39,10 +44,10 @@ defmodule EctoOrderedTest do
   end
 
   test "inserting item with an inserting position" do
-    model1 = %Model{title: "item with no position, going to be #1"} |> Repo.insert
-    model2 = %Model{title: "item with no position, going to be #2"} |> Repo.insert
-    model3 = %Model{title: "item with no position, going to be #3"} |> Repo.insert
-    model = %Model{title: "item #2", position: 2} |> Repo.insert
+    model1 = %Model{title: "item with no position, going to be #1"} |> Repo.insert!
+    model2 = %Model{title: "item with no position, going to be #2"} |> Repo.insert!
+    model3 = %Model{title: "item with no position, going to be #3"} |> Repo.insert!
+    model = %Model{title: "item #2", position: 2} |> Repo.insert!
     assert model.position == 2
     assert Repo.get(Model, model1.id).position == 1
     assert Repo.get(Model, model2.id).position == 3
@@ -50,10 +55,10 @@ defmodule EctoOrderedTest do
   end
 
   test "inserting item with an inserting position at #1" do
-    model1 = %Model{title: "item with no position, going to be #1"} |> Repo.insert
-    model2 = %Model{title: "item with no position, going to be #2"} |> Repo.insert
-    model3 = %Model{title: "item with no position, going to be #3"} |> Repo.insert
-    model = %Model{title: "item #1", position: 1} |> Repo.insert
+    model1 = %Model{title: "item with no position, going to be #1"} |> Repo.insert!
+    model2 = %Model{title: "item with no position, going to be #2"} |> Repo.insert!
+    model3 = %Model{title: "item with no position, going to be #3"} |> Repo.insert!
+    model = %Model{title: "item #1", position: 1} |> Repo.insert!
     assert model.position == 1
     assert Repo.get(Model, model1.id).position == 2
     assert Repo.get(Model, model2.id).position == 3
@@ -63,17 +68,17 @@ defmodule EctoOrderedTest do
   ## Moving
 
   test "updating item with the same position" do
-    model = %Model{title: "item with no position"} |> Repo.insert
-    model1 = %Model{model | title: "item with a position"} |> Repo.update
+    model = %Model{title: "item with no position"} |> Repo.insert!
+    model1 = %Model{model | title: "item with a position"} |> Repo.update!
     assert model.position == model1.position
   end
 
   test "replacing an item below" do
-    model1 = %Model{title: "item #1"} |> Repo.insert
-    model2 = %Model{title: "item #2"} |> Repo.insert
-    model3 = %Model{title: "item #3"} |> Repo.insert
-    model4 = %Model{title: "item #4"} |> Repo.insert
-    model5 = %Model{title: "item #5"} |> Repo.insert
+    model1 = %Model{title: "item #1"} |> Repo.insert!
+    model2 = %Model{title: "item #2"} |> Repo.insert!
+    model3 = %Model{title: "item #3"} |> Repo.insert!
+    model4 = %Model{title: "item #4"} |> Repo.insert!
+    model5 = %Model{title: "item #5"} |> Repo.insert!
 
     model2 |> Model.move_position(4) |> Repo.update
 
@@ -85,11 +90,11 @@ defmodule EctoOrderedTest do
   end
 
   test "replacing an item above" do
-    model1 = %Model{title: "item #1"} |> Repo.insert
-    model2 = %Model{title: "item #2"} |> Repo.insert
-    model3 = %Model{title: "item #3"} |> Repo.insert
-    model4 = %Model{title: "item #4"} |> Repo.insert
-    model5 = %Model{title: "item #5"} |> Repo.insert
+    model1 = %Model{title: "item #1"} |> Repo.insert!
+    model2 = %Model{title: "item #2"} |> Repo.insert!
+    model3 = %Model{title: "item #3"} |> Repo.insert!
+    model4 = %Model{title: "item #4"} |> Repo.insert!
+    model5 = %Model{title: "item #5"} |> Repo.insert!
 
     model4 |> Model.move_position(2) |> Repo.update
 
@@ -101,9 +106,9 @@ defmodule EctoOrderedTest do
   end
 
   test "updating item with a tail position" do
-    model1 = %Model{title: "item #1"} |> Repo.insert
-    model2 = %Model{title: "item #2"} |> Repo.insert
-    model3 = %Model{title: "item #3"} |> Repo.insert
+    model1 = %Model{title: "item #1"} |> Repo.insert!
+    model2 = %Model{title: "item #2"} |> Repo.insert!
+    model3 = %Model{title: "item #3"} |> Repo.insert!
 
     model2 |> Model.move_position(4) |> Repo.update
 
@@ -115,11 +120,11 @@ defmodule EctoOrderedTest do
   ## Deletion
 
   test "deleting an item" do
-    model1 = %Model{title: "item #1"} |> Repo.insert
-    model2 = %Model{title: "item #2"} |> Repo.insert
-    model3 = %Model{title: "item #3"} |> Repo.insert
-    model4 = %Model{title: "item #4"} |> Repo.insert
-    model5 = %Model{title: "item #5"} |> Repo.insert
+    model1 = %Model{title: "item #1"} |> Repo.insert!
+    model2 = %Model{title: "item #2"} |> Repo.insert!
+    model3 = %Model{title: "item #3"} |> Repo.insert!
+    model4 = %Model{title: "item #4"} |> Repo.insert!
+    model5 = %Model{title: "item #5"} |> Repo.insert!
 
     model2 |> Repo.delete
 
@@ -148,11 +153,14 @@ defmodule EctoOrderedTest.Scoped do
     end
   end
 
+  setup do
+    Ecto.Adapters.SQL.restart_test_transaction(EctoOrderedTest.Repo)
+  end
   # Insertion
 
   test "scoped: inserting item with no position" do
     for s <- 1..10, i <- 1..10 do
-      model = %Model{scope: s, title: "item with no position, going to be ##{i}"} |> Repo.insert
+      model = %Model{scope: s, title: "item with no position, going to be ##{i}"} |> Repo.insert!
       assert model.scoped_position == i
     end
     for s <- 1..10 do
@@ -166,7 +174,7 @@ defmodule EctoOrderedTest.Scoped do
     %Model{scope: 10, title: "item with no position, going to be #1"} |> Repo.insert
     %Model{scope: 11, title: "item #2"} |> Repo.insert
 
-    model = %Model{scope: 10, title: "item #2", scoped_position: 2} |> Repo.insert
+    model = %Model{scope: 10, title: "item #2", scoped_position: 2} |> Repo.insert!
 
     assert model.scoped_position == 2
   end
@@ -179,11 +187,11 @@ defmodule EctoOrderedTest.Scoped do
   end
 
   test "scoped: inserting item with an inserting position" do
-    model1 = %Model{scope: 1, title: "item with no position, going to be #1"} |> Repo.insert
-    model2 = %Model{scope: 1, title: "item with no position, going to be #2"} |> Repo.insert
-    model3 = %Model{scope: 1, title: "item with no position, going to be #3"} |> Repo.insert
+    model1 = %Model{scope: 1, title: "item with no position, going to be #1"} |> Repo.insert!
+    model2 = %Model{scope: 1, title: "item with no position, going to be #2"} |> Repo.insert!
+    model3 = %Model{scope: 1, title: "item with no position, going to be #3"} |> Repo.insert!
 
-    model = %Model{scope: 1,  title: "item #2", scoped_position: 2} |> Repo.insert
+    model = %Model{scope: 1,  title: "item #2", scoped_position: 2} |> Repo.insert!
 
     assert model.scoped_position == 2
     assert Repo.get(Model, model1.id).scoped_position == 1
@@ -192,10 +200,10 @@ defmodule EctoOrderedTest.Scoped do
   end
 
   test "scoped: inserting item with an inserting position at #1" do
-    model1 = %Model{scope: 1, title: "item with no position, going to be #1"} |> Repo.insert
-    model2 = %Model{scope: 1, title: "item with no position, going to be #2"} |> Repo.insert
-    model3 = %Model{scope: 1, title: "item with no position, going to be #3"} |> Repo.insert
-    model = %Model{scope: 1, title: "item #1", scoped_position: 1} |> Repo.insert
+    model1 = %Model{scope: 1, title: "item with no position, going to be #1"} |> Repo.insert!
+    model2 = %Model{scope: 1, title: "item with no position, going to be #2"} |> Repo.insert!
+    model3 = %Model{scope: 1, title: "item with no position, going to be #3"} |> Repo.insert!
+    model = %Model{scope: 1, title: "item #1", scoped_position: 1} |> Repo.insert!
     assert model.scoped_position == 1
     assert Repo.get(Model, model1.id).scoped_position == 2
     assert Repo.get(Model, model2.id).scoped_position == 3
@@ -205,17 +213,17 @@ defmodule EctoOrderedTest.Scoped do
   ## Moving
 
   test "scoped: updating item with the same position" do
-    model = %Model{scope: 1, title: "item with no position"} |> Repo.insert
-    model1 = %Model{model | title: "item with a position", scope: 1} |> Repo.update
+    model = %Model{scope: 1, title: "item with no position"} |> Repo.insert!
+    model1 = %Model{model | title: "item with a position", scope: 1} |> Repo.update!
     assert model.scoped_position == model1.scoped_position
   end
 
   test "scoped: replacing an item below" do
-    model1 = %Model{scope: 1, title: "item #1"} |> Repo.insert
-    model2 = %Model{scope: 1, title: "item #2"} |> Repo.insert
-    model3 = %Model{scope: 1, title: "item #3"} |> Repo.insert
-    model4 = %Model{scope: 1, title: "item #4"} |> Repo.insert
-    model5 = %Model{scope: 1, title: "item #5"} |> Repo.insert
+    model1 = %Model{scope: 1, title: "item #1"} |> Repo.insert!
+    model2 = %Model{scope: 1, title: "item #2"} |> Repo.insert!
+    model3 = %Model{scope: 1, title: "item #3"} |> Repo.insert!
+    model4 = %Model{scope: 1, title: "item #4"} |> Repo.insert!
+    model5 = %Model{scope: 1, title: "item #5"} |> Repo.insert!
 
     model2 |> Model.move_scoped_position(4) |> Repo.update
 
@@ -227,11 +235,11 @@ defmodule EctoOrderedTest.Scoped do
   end
 
   test "scoped: replacing an item above" do
-    model1 = %Model{scope: 1, title: "item #1"} |> Repo.insert
-    model2 = %Model{scope: 1, title: "item #2"} |> Repo.insert
-    model3 = %Model{scope: 1, title: "item #3"} |> Repo.insert
-    model4 = %Model{scope: 1, title: "item #4"} |> Repo.insert
-    model5 = %Model{scope: 1, title: "item #5"} |> Repo.insert
+    model1 = %Model{scope: 1, title: "item #1"} |> Repo.insert!
+    model2 = %Model{scope: 1, title: "item #2"} |> Repo.insert!
+    model3 = %Model{scope: 1, title: "item #3"} |> Repo.insert!
+    model4 = %Model{scope: 1, title: "item #4"} |> Repo.insert!
+    model5 = %Model{scope: 1, title: "item #5"} |> Repo.insert!
 
     model4 |> Model.move_scoped_position(2) |> Repo.update
 
@@ -243,9 +251,9 @@ defmodule EctoOrderedTest.Scoped do
   end
 
   test "scoped: updating item with a tail position" do
-    model1 = %Model{scope: 1, title: "item #1"} |> Repo.insert
-    model2 = %Model{scope: 1, title: "item #2"} |> Repo.insert
-    model3 = %Model{scope: 1, title: "item #3"} |> Repo.insert
+    model1 = %Model{scope: 1, title: "item #1"} |> Repo.insert!
+    model2 = %Model{scope: 1, title: "item #2"} |> Repo.insert!
+    model3 = %Model{scope: 1, title: "item #3"} |> Repo.insert!
 
     model2 |> Model.move_scoped_position(4) |> Repo.update
 
@@ -255,13 +263,13 @@ defmodule EctoOrderedTest.Scoped do
   end
 
   test "scoped: moving between scopes" do
-    model1 = %Model{scope: 1, title: "item #1"} |> Repo.insert
-    model2 = %Model{scope: 1, title: "item #2"} |> Repo.insert
-    model3 = %Model{scope: 1, title: "item #3"} |> Repo.insert
+    model1 = %Model{scope: 1, title: "item #1"} |> Repo.insert!
+    model2 = %Model{scope: 1, title: "item #2"} |> Repo.insert!
+    model3 = %Model{scope: 1, title: "item #3"} |> Repo.insert!
 
-    xmodel1 = %Model{scope: 2, title: "item #1"} |> Repo.insert
-    xmodel2 = %Model{scope: 2, title: "item #2"} |> Repo.insert
-    xmodel3 = %Model{scope: 2, title: "item #3"} |> Repo.insert
+    xmodel1 = %Model{scope: 2, title: "item #1"} |> Repo.insert!
+    xmodel2 = %Model{scope: 2, title: "item #2"} |> Repo.insert!
+    xmodel3 = %Model{scope: 2, title: "item #3"} |> Repo.insert!
 
     model2 |> Model.move_scoped_position(4) |> Ecto.Changeset.put_change(:scope, 2) |> Repo.update
 
@@ -280,11 +288,11 @@ defmodule EctoOrderedTest.Scoped do
   ## Deletion
 
   test "scoped: deleting an item" do
-    model1 = %Model{title: "item #1", scope: 1} |> Repo.insert
-    model2 = %Model{title: "item #2", scope: 1} |> Repo.insert
-    model3 = %Model{title: "item #3", scope: 1} |> Repo.insert
-    model4 = %Model{title: "item #4", scope: 1} |> Repo.insert
-    model5 = %Model{title: "item #5", scope: 1} |> Repo.insert
+    model1 = %Model{title: "item #1", scope: 1} |> Repo.insert!
+    model2 = %Model{title: "item #2", scope: 1} |> Repo.insert!
+    model3 = %Model{title: "item #3", scope: 1} |> Repo.insert!
+    model4 = %Model{title: "item #4", scope: 1} |> Repo.insert!
+    model5 = %Model{title: "item #5", scope: 1} |> Repo.insert!
 
     model2 |> Repo.delete
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,38 +1,13 @@
-Logger.configure level: :debug
-Application.put_env(:ecto_ordered, EctoOrderedTest.Repo, url: "ecto://postgres:postgres@localhost/ecto_ordered_test")
+Logger.configure level: :error
+Application.put_env(:ecto_ordered, EctoOrderedTest.Repo, pool: Ecto.Adapters.SQL.Sandbox,
+                    database: "ecto_ordered_test",
+                    url: System.get_env("DATABASE_URL") || "ecto://postgres:postgres@localhost/ecto_ordered_test")
 
-setup_cmds = [
-  ~s(psql -U postgres -c "DROP DATABASE IF EXISTS ecto_ordered_test;"),
-  ~s(psql -U postgres -c "CREATE DATABASE ecto_ordered_test TEMPLATE=template0 ENCODING='UTF8' LC_COLLATE='en_US.UTF-8' LC_CTYPE='en_US.UTF-8';")
-]
-
+Code.require_file "test_migrations.exs", __DIR__
 defmodule EctoOrderedTest.Repo do
   use Ecto.Repo, otp_app: :ecto_ordered,
                  adapter: Ecto.Adapters.Postgres
 end
-
-Enum.each(setup_cmds, fn(cmd) ->
-  key = :ecto_setup_cmd_output
-  Process.put(key, "")
-  status = Mix.Shell.cmd(cmd, fn(data) ->
-    current = Process.get(key)
-    Process.put(key, current <> data)
-  end)
-
-  if status != 0 do
-    IO.puts """
-    Test setup command error'd:
-    #{cmd}
-    With:
-    #{Process.get(key)}
-    Please verify the user "postgres" exists and it has permissions
-    to create databases. If not, you can create a new user with:
-    createuser postgres --no-password -d
-    """
-    System.halt(1)
-  end
-end)
-
 
 defmodule EctoOrdered.TestCase do
   use ExUnit.CaseTemplate
@@ -51,31 +26,11 @@ defmodule EctoOrdered.TestCase do
     end
   end
 
-  setup do
-    Logger.configure level: :error
-    setup_database = [
-      "DROP TABLE IF EXISTS model",
-      "DROP TABLE IF EXISTS scoped_model",
-      "CREATE TABLE model (id serial PRIMARY KEY, title varchar(100), position integer)",
-      "CREATE TABLE scoped_model (id serial PRIMARY KEY, title varchar(100), scope integer,scoped_position integer)",
-      # "ALTER TABLE model ADD CONSTRAINT position_unique UNIQUE (position)",
-      # "ALTER TABLE scoped_model ADD CONSTRAINT scoped_position_unique UNIQUE (scoped_position, scope)",
-    ]
-
-    {:ok, _pid} = EctoOrderedTest.Repo.start_link
-
-    Enum.each(setup_database, fn(sql) ->
-      result = Ecto.Adapters.SQL.query(EctoOrderedTest.Repo, sql, [])
-      if match?({:error, _}, result) do
-        IO.puts("Test database setup SQL error'd: `#{sql}`")
-        IO.inspect(result)
-        System.halt(1)
-      end
-    end)
-    on_exit fn ->
-      Logger.configure level: :debug
-    end
-  end
 end
 
-ExUnit.start
+EctoOrderedTest.Repo.start_link
+_ = Ecto.Migrator.up(EctoOrderedTest.Repo, 0, EctoOrderedTest.Migrations)
+Ecto.Adapters.SQL.begin_test_transaction(EctoOrderedTest.Repo)
+
+ExUnit.configure(exclude: [skip: true])
+ExUnit.start()

--- a/test/test_migrations.exs
+++ b/test/test_migrations.exs
@@ -1,0 +1,16 @@
+defmodule EctoOrderedTest.Migrations do
+  use Ecto.Migration
+
+  def change do
+    create table(:model) do
+      add :title, :string
+      add :position, :integer
+    end
+
+    create table(:scoped_model) do
+      add :title, :string
+      add :scope, :integer
+      add :scoped_position, :integer
+    end
+  end
+end


### PR DESCRIPTION
Callbacks have been deprecated in Ecto 1.1 (and removed in Ecto 2.0) and
they involve considerable magic, so this seemed like a good solution.

We use the `Ecto.Changeset.prepare_changes/2` function to do the
reordering inside the same transaction as the changes to the model.

This does mean that the interface must become a bit more explicit: A
call to `EctoOrdered.set_order/3` should be included in the changeset
methods. Also this means that one cannot simply delete records without
using a changeset - the ordering would be messed up if this were done.

A delete function like this is required:

``` elixir
def delete(model) do
  model
  |> cast(%{}, ~w(), ~w())
  |> Map.put(:action, :delete)
  |> set_order(:position)
end
```
