### PR TITLE
Move from recording explicit positions to sortable integers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ defmodule MyModel do
   import EctoOrdered
 
   schema "models" do
-    field :position, :integer
+    field :position, :integer, virtual: true
+    field, :rank, :integer
   end
   
   def changeset(model, params) do
@@ -31,7 +32,7 @@ defmodule MyModel do
 
   schema "models" do
     field :reference_id, :integer
-    field :position,     :integer
+    field :position,     :integer, virtual: true
   end
   
   def changeset(model, params) do

--- a/lib/ecto_ordered.ex
+++ b/lib/ecto_ordered.ex
@@ -185,8 +185,8 @@ defmodule EctoOrdered do
     current_first = get_current_first(options, cs)
     current_last = get_current_last(options, cs)
     cond do
-      current_first > @min && current_rank == @max -> shift_others_down(options, cs)
-      current_last < @max - 1 && current_rank < current_last -> shift_others_up(options, cs)
+      current_first > @min && current_rank == @max -> decrement_other_ranks(options, cs)
+      current_last < @max - 1 && current_rank < current_last -> increment_other_ranks(options, cs)
       true -> rebalance_ranks(options, cs)
     end
   end
@@ -228,7 +228,7 @@ defmodule EctoOrdered do
     |> cs.repo.all
   end
 
-  defp shift_others_up(%Options{rank_field: rank_field} = options, %{data: existing} = cs) do
+  defp increment_other_ranks(%Options{rank_field: rank_field} = options, %{data: existing} = cs) do
     current_rank = get_field(cs, rank_field)
     options.module
     |> where([r], field(r, ^rank_field) >= ^current_rank)
@@ -237,7 +237,7 @@ defmodule EctoOrdered do
     cs
   end
 
-  defp shift_others_down(%Options{rank_field: rank_field} = options, %{data: existing} = cs) do
+  defp decrement_other_ranks(%Options{rank_field: rank_field} = options, %{data: existing} = cs) do
     current_rank = get_field(cs, rank_field)
     options.module
     |> where([r], field(r, ^rank_field) <= ^current_rank)

--- a/lib/ecto_ordered.ex
+++ b/lib/ecto_ordered.ex
@@ -70,7 +70,7 @@ defmodule EctoOrdered do
 
   @doc false
   def before_insert(cs, position_field, rank_field, scope_field) do
-    struct = %Order{module: cs.data.__struct__,
+    order = %Order{module: cs.data.__struct__,
                     position_field: position_field,
                     rank_field: rank_field,
                     scope_field: scope_field,
@@ -88,7 +88,7 @@ defmodule EctoOrdered do
 
   @doc false
   def before_update(cs, position_field, rank_field, scope_field \\ nil) do
-    struct = %Order{module: cs.data.__struct__,
+    order = %Order{module: cs.data.__struct__,
                     position_field: position_field,
                     rank_field: rank_field,
                     scope_field: scope_field,
@@ -174,7 +174,7 @@ defmodule EctoOrdered do
   end
 
   defp shift_others_up(%Order{rank_field: rank_field,
-                              repo: repo} = order, %{model: existing} = cs) do
+                              repo: repo} = order, %{data: existing} = cs) do
     current_rank = get_field(cs, rank_field)
     order
     |> queryable
@@ -185,7 +185,7 @@ defmodule EctoOrdered do
   end
 
   defp shift_others_down(%Order{rank_field: rank_field,
-                                repo: repo} = order, %{model: existing} = cs) do
+                                repo: repo} = order, %{data: existing} = cs) do
     current_rank = get_field(cs, rank_field)
     order
     |> queryable
@@ -225,7 +225,7 @@ defmodule EctoOrdered do
 
   defp neighbours_at_position(%Order{rank_field: rank_field,
                                      repo: repo
-                          } = order, position, %{model: existing} = cs) do
+                          } = order, position, %{data: existing} = cs) do
     %Order{current_last: current_last} = update_current_last(order, cs)
     neighbours = order
     |> queryable

--- a/lib/ecto_ordered.ex
+++ b/lib/ecto_ordered.ex
@@ -212,6 +212,9 @@ defmodule EctoOrdered do
     put_change(cs, rank_field, rank_for_row(0, get_field(cs, position_field), count, 1))
   end
 
+  defp rank_for_row(old_rank, :last, count, old_attempted_rank) do
+    rank_for_row(old_rank, count - 1, count, old_attempted_rank)
+  end
   defp rank_for_row(old_rank, index, count, old_attempted_rank) do
     # If our old rank is less than the old attempted rank, then our effective index is fine
     new_index = if old_rank < old_attempted_rank do
@@ -220,6 +223,7 @@ defmodule EctoOrdered do
     else
       index + 1
     end
+
     round((@max - @min) / count) * new_index + @min
   end
 

--- a/lib/ecto_ordered.ex
+++ b/lib/ecto_ordered.ex
@@ -49,7 +49,7 @@ defmodule EctoOrdered do
   - `rank_field` the field in which the ranking should be stored
   - `scope` the field in which the scope for the order should be stored (optional)
   """
-  def set_order(changeset, position_field, rank_field, scope_field \\ nil) do
+  def set_order(changeset, position_field \\ :position, rank_field \\ :rank, scope_field \\ nil) do
     changeset
     |> prepare_changes(fn changeset ->
       case changeset.action do

--- a/lib/ecto_ordered.ex
+++ b/lib/ecto_ordered.ex
@@ -11,26 +11,19 @@ defmodule EctoOrdered do
 
     schema "ordered_list_item" do
       field :title,            :string
-      field :position,         :integer
+      field :position,         :integer, virtual: true
+      field :rank,             :integer
+      field :move,             :any, virtual: true
     end
 
     def changeset(model, params) do
       model
-      |> cast(params, [:position, :title])
-      |> set_order(:position)
-    end
-
-    def delete(model) do
-      model
-      |> cast(%{}, [])
-      |> Map.put(:action, :delete)
-      |> set_order(:position)
+      |> cast(params, [:position, :title, :move])
+      |> set_order(:position, :rank)
     end
   end
   ```
 
-  Note the `delete` function used to ensure that the remaining items are repositioned on
-  deletion.
 
   """
 
@@ -52,7 +45,8 @@ defmodule EctoOrdered do
 
   The arguments are as follows:
   - `changeset` the changeset which is part of the ordered list
-  - `field` the field in which the order should be stored
+  - `position_field` the (virtual) field in which the order is set
+  - `rank_field` the field in which the ranking should be stored
   - `scope` the field in which the scope for the order should be stored (optional)
   """
   def set_order(changeset, position_field, rank_field, scope_field \\ nil) do

--- a/lib/ecto_ordered.ex
+++ b/lib/ecto_ordered.ex
@@ -34,17 +34,15 @@ defmodule EctoOrdered do
 
   """
 
+  @max 8388607
+  @min -8388607
+
   defstruct repo:         nil,
             module:       nil,
-            field:        :position,
-            new_position: nil,
-            old_position: nil,
-            move:         :move_position,
-            scope:        nil,
-            old_scope:    nil,
-            new_scope:    nil,
-            until:        nil,
-            max:          nil
+            position_field:        :position,
+            rank_field: :rank,
+            scope_field:        nil,
+            current_last: nil
 
   defmodule InvalidMove do
     defexception type: nil
@@ -65,190 +63,134 @@ defmodule EctoOrdered do
   - `field` the field in which the order should be stored
   - `scope` the field in which the scope for the order should be stored (optional)
   """
-  def set_order(changeset, field, scope \\ nil) do
-    prepare_changes(changeset, fn changeset ->
+  def set_order(changeset, position_field, rank_field, scope_field \\ nil) do
+    changeset
+    |> prepare_changes( fn changeset ->
       case changeset.action do
-        :insert -> EctoOrdered.before_insert changeset, %EctoOrdered{repo: changeset.repo,
-                                                                    field: field,
-                                                                    scope: scope}
-        :update -> EctoOrdered.before_update changeset, %EctoOrdered{repo: changeset.repo,
-                                                                    field: field,
-                                                                    scope: scope}
-        :delete -> EctoOrdered.before_delete changeset, %EctoOrdered{repo: changeset.repo,
-                                                                    field: field,
-                                                                    scope: scope}
+        :insert -> EctoOrdered.before_insert changeset, position_field, rank_field, scope_field
+        :update -> EctoOrdered.before_update changeset, position_field, rank_field, scope_field
       end
     end)
   end
 
   @doc false
-  def before_insert(cs, %Order{field: field} = struct) do
-    struct = %{struct|module: cs.data.__struct__}
-    struct = %Order{max: max} = update_max(struct, cs)
-    position_assigned = get_field(cs, field)
+  def before_insert(cs, position_field, rank_field, scope_field) do
+    struct = %Order{module: cs.data.__struct__,
+                    position_field: position_field,
+                    rank_field: rank_field,
+                    scope_field: scope_field,
+                    repo: cs.repo
+                   }
 
-    if position_assigned do
-      struct = struct
-      |> update_new_scope(cs)
-      |> update_new_position(cs)
-      increment_position(struct)
-      validate_position!(cs, struct)
+    if get_field(cs, position_field) do
+      update_rank(struct, cs)
     else
-      put_change(cs, field, max + 1)
+      update_rank(struct, put_change(cs, position_field, :last))
     end
   end
 
   @doc false
-  def before_update(cs, struct) do
-    %{struct|module: cs.data.__struct__}
-    |> update_old_scope(cs)
-    |> update_new_scope(cs)
-    |> reorder_model(cs)
+  def before_update(cs, position_field, rank_field, scope_field \\ nil) do
+    struct = %Order{module: cs.data.__struct__,
+                    position_field: position_field,
+                    rank_field: rank_field,
+                    scope_field: scope_field,
+                    repo: cs.repo
+                   }
+    case fetch_change(cs, position_field) do
+      {:ok, _} -> update_rank(struct, cs)
+      :error -> cs
+    end
   end
 
-  defp increment_position(%Order{module: module, field: field, scope: nil, new_position: split_by} = struct) do
-    query = from m in module,
-            where: field(m, ^field) >= ^split_by
-    execute_increment(struct, query)
+  defp update_rank(%Order{rank_field: rank_field, position_field: position_field} = struct, cs) do
+    case get_field(cs, position_field) do
+      :last -> %Order{current_last: current_last} = update_current_last(struct)
+        if current_last do
+          put_change(cs, rank_field, rank_between(@max, current_last))
+        else
+          update_rank(struct, put_change(cs, position_field, :middle))
+        end
+      :middle -> put_change(cs, rank_field, rank_between(@max, @min))
+      nil -> update_rank(struct, put_change(cs, position_field, :last))
+      position when is_integer(position) ->
+        {rank_before, rank_after} = neighbours_at_position(struct, position, cs.data)
+        put_change(cs, rank_field, rank_between(rank_after, rank_before))
+    end
   end
 
-  defp increment_position(%Order{module: module, field: field, scope: scope, new_position: split_by, new_scope: new_scope} = struct) do
-    query = from m in module,
-            where: field(m, ^field) >= ^split_by and field(m, ^scope) == ^new_scope
-    execute_increment(struct, query)
+  defp neighbours_at_position(%Order{module: module,
+                                     rank_field: rank_field,
+                                     repo: repo
+                                    }, position, _) when position <= 0 do
+    first = (from m in module,
+             select: field(m, ^rank_field),
+             order_by: [asc: field(m, ^rank_field)],
+             limit: 1
+    ) |> repo.one
+
+    {@min, first}
   end
 
-  defp decrement_position(%Order{module: module, field: field, old_position: split_by, until: until, scope: nil} = struct) do
-    query = from m in module,
-            where: field(m, ^field) > ^split_by and field(m, ^field) <= ^until
-    execute_decrement(struct, query)
+  defp neighbours_at_position(%Order{module: module,
+                                     rank_field: rank_field,
+                                     repo: repo
+                          } = struct, position, existing) do
+    %Order{current_last: current_last} = update_current_last(struct)
+    neighbours = (from m in module,
+     select: field(m, ^rank_field),
+     order_by: [asc: field(m, ^rank_field)],
+     limit: 2,
+     offset: ^(position - 1)
+    )
+    |> exclude_existing(existing)
+    |> repo.all
+    case neighbours do
+      [] -> {current_last, @max}
+      [bef] -> {bef, @max}
+      [bef, aft] -> {bef, aft}
+    end
   end
 
-  defp decrement_position(%Order{module: module, field: field, old_position: split_by, until: nil, old_scope: old_scope, scope: scope} = struct) do
-    query = from m in module,
-    where: field(m, ^field) > ^split_by
-    and field(m, ^scope) == ^old_scope
-    execute_decrement(struct, query)
-  end
-
-  defp decrement_position(%Order{module: module, field: field, scope: scope, old_position: split_by, until: until, old_scope: old_scope} = struct) do
-    query = from m in module,
-    where: field(m, ^field) > ^split_by and field(m, ^field) <= ^until
-            and field(m, ^scope) == ^old_scope
-    execute_decrement(struct, query)
-  end
-
-  defp validate_position!(cs, %Order{field: field, new_position: position, max: max}) when position > max + 1 do
-    raise EctoOrdered.InvalidMove, type: :too_large
-    %Ecto.Changeset{ cs | valid?: false } |> add_error(field, :too_large)
-  end
-  defp validate_position!(cs, %Order{field: field, new_position: position}) when position < 1 do
-    raise EctoOrdered.InvalidMove, type: :too_small
-    %Ecto.Changeset{ cs | valid?: false } |> add_error(field, :too_small)
-  end
-  defp validate_position!(cs, _), do: cs
-
-  defp update_old_scope(%Order{scope: scope} = struct, cs) do
-    %{struct|old_scope: Map.get(cs.data, scope)}
-  end
-
-  defp update_new_scope(%Order{scope: scope} = struct, cs) do
-    %{struct|new_scope: get_field(cs, scope)}
-  end
-
-  defp update_new_position(%Order{field: field} = struct, cs) do
-    %{struct|new_position: get_field(cs, field)}
-  end
-
-  defp update_old_position(%Order{field: field} = struct, cs) do
-    %{struct|old_position: Map.get(cs.data, field)}
-  end
-
-  defp update_max(%Order{repo: repo} = struct, cs) do
-    rows = query(struct, cs) |> repo.all
-    max = (rows == [] && 0) || Enum.max(rows)
-    %{struct|max: max}
-  end
-
-
-  defp reorder_model(%Order{scope: scope, old_scope: old_scope, new_scope: new_scope} = struct, cs)
-      when not is_nil(old_scope) and new_scope != old_scope do
-    cs
-    |> put_change(scope, new_scope)
-    |> before_delete(struct)
-
-    before_insert(cs, struct)
-  end
-  defp reorder_model(struct, cs) do
-    struct
-    |> update_max(cs)
-    |> update_new_position(cs)
-    |> update_old_position(cs)
-    |> adjust_position(cs)
-  end
-
-  defp adjust_position(%Order{max: max, field: field, new_position: new_position, old_position: old_position} = struct, cs)
-      when new_position > old_position do
-    struct = %{struct|until: new_position}
-
-    decrement_position(struct)
-    cs = if new_position == max + 1, do: put_change(cs, field, max), else: cs
-    validate_position!(cs, struct)
-  end
-  defp adjust_position(%Order{max: max, new_position: new_position, old_position: old_position} = struct, cs)
-      when new_position < old_position do
-    struct = %{struct|until: max}
-
-    decrement_position(struct)
-    increment_position(struct)
-    validate_position!(cs, struct)
-  end
-
-  defp adjust_position(_struct, cs) do
-    cs
-  end
-
-  @doc false
-  def before_delete(cs, struct) do
-    struct = %Order{max: max} = %{struct | module: cs.data.__struct__}
-                                |> update_max(cs)
-                                |> update_old_position(cs)
-                                |> update_old_scope(cs)
-    decrement_position(%{struct|until: max})
-    cs
-  end
-
-  defp query(%Order{module: module, field: field, scope: nil}, _cs) do
-    from(m in module) |> selector(field)
-  end
-
-  defp query(%Order{module: module, field: field, scope: scope}, cs) do
-     new_scope = get_field(cs, scope)
-     scope_query(module, field, scope, new_scope)
-  end
-
-  defp selector(q, field) do
-    Ecto.Query.select(q, [m], field(m, ^field))
-  end
-
-  defp execute_increment(%Order{repo: repo, field: field}, query) do
+  defp exclude_existing(query, %{id: nil}) do
     query
-    |> repo.update_all([inc: [{field, 1}]])
   end
 
-  defp execute_decrement(%Order{repo: repo, field: field}, query) do
-    query |> repo.update_all([inc: [{field, -1}]])
+  defp exclude_existing(query, existing) do
+    from r in query, where: r.id != ^existing.id
   end
 
-  defp scope_query(q, field, scope, nil) do
-    q
-    |> selector(field)
-    |> where([m], is_nil(field(m, ^scope)))
+  defp update_current_last(%Order{current_last: nil,
+                                module: module,
+                                rank_field: rank_field,
+                                repo: repo
+                               } = struct) do
+    last = (from m in module,
+            select: field(m, ^rank_field),
+            order_by: [desc: field(m, ^rank_field)],
+            limit: 1
+    )
+    |> repo.one
+    if last do
+    %Order{struct | current_last: last}
+    else
+      %Order{struct | current_last: @min}
+    end
   end
 
-  defp scope_query(q, field, scope, new_scope) do
-    q
-    |> selector(field)
-    |> where([m], field(m, ^scope) == ^new_scope)
+  defp update_current_last(%Order{} = struct) do
+    # noop. We've already got the last.
+    struct
   end
+
+  defp rank_between(nil, nil) do
+    rank_between(8388607, -8388607)
+  end
+
+  defp rank_between(above, below) do
+    ( above - below ) / 2
+    |> round
+    |> + below
+  end
+
 end

--- a/lib/ecto_ordered.ex
+++ b/lib/ecto_ordered.ex
@@ -34,8 +34,9 @@ defmodule EctoOrdered do
 
   """
 
-  @max 8388607
-  @min -8388607
+  # These are the max bounds of an INT in postgresql
+  @max 2147483647
+  @min -2147483648
 
   defstruct repo:         nil,
             module:       nil,
@@ -308,7 +309,7 @@ defmodule EctoOrdered do
 
 
   defp rank_between(nil, nil) do
-    rank_between(8388607, -8388607)
+    rank_between(@max, @min)
   end
 
   defp rank_between(above, below) do

--- a/mix.exs
+++ b/mix.exs
@@ -46,6 +46,7 @@ defmodule EctoOrdered.Mixfile do
     [
      {:ecto, "~> 2.0"},
      {:postgrex, "~> 0.11.0", only: :test},
+     {:credo, "~> 0.3", only: [:dev, :test]},
      {:ex_doc, "~> 0.11.4", only: :dev},
      {:earmark, ">= 0.0.0", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
+%{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
+  "credo": {:hex, :credo, "0.4.12", "f5e1973405ea25c6e64959fb0b6bf92950147a0278cc2a002a491b45f78f7b87", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
   "db_connection": {:hex, :db_connection, "1.0.0-rc.5", "1d9ab6e01387bdf2de7a16c56866971f7c2f75aea7c69cae2a0346e4b537ae0d", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0.0-beta.3", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.2.0", "462960fd71af282e570f7b477f6be56bf8968e68277d4d0b641a635269bf4b0d", [:mix], []},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},

--- a/priv/test/repo/migrations/0_test_migrations.exs
+++ b/priv/test/repo/migrations/0_test_migrations.exs
@@ -4,7 +4,7 @@ defmodule EctoOrderedTest.Migrations do
   def change do
     create table(:model) do
       add :title, :string
-      add :position, :integer
+      add :rank, :integer
     end
 
     create table(:scoped_model) do

--- a/priv/test/repo/migrations/0_test_migrations.exs
+++ b/priv/test/repo/migrations/0_test_migrations.exs
@@ -10,7 +10,7 @@ defmodule EctoOrderedTest.Migrations do
     create table(:scoped_model) do
       add :title, :string
       add :scope, :integer
-      add :scoped_position, :integer
+      add :scoped_rank, :integer
     end
   end
 end

--- a/test/ecto_ordered_test.exs
+++ b/test/ecto_ordered_test.exs
@@ -150,6 +150,37 @@ defmodule EctoOrderedTest do
     assert ranked_ids(Model) == [model1.id, model3.id, model4.id, model5.id]
   end
 
+  test "collision handling at max" do
+    for _ <- 1..100 do
+      Model.changeset(%Model{}, %{}) |> Repo.insert!
+    end
+
+    ranks = (from m in Model, order_by: m.rank, select: m.rank) |> Repo.all
+
+    assert ranks == Enum.uniq(ranks)
+  end
+
+  test "collision handling at min" do
+    for _ <- 1..100 do
+        Model.changeset(%Model{}, %{position: 0}) |> Repo.insert
+    end
+
+    ranks = (from m in Model, order_by: m.rank, select: m.rank) |> Repo.all
+
+    assert ranks == Enum.uniq(ranks)
+  end
+  test "collision handling in the middle" do
+    for _ <- 1..25 do
+      Model.changeset(%Model{}, %{position: 0}) |> Repo.insert!
+    end
+    for _ <- 1..25 do
+      Model.changeset(%Model{}, %{position: 1000}) |> Repo.insert!
+    end
+    ranks = (from m in Model, order_by: m.rank, select: m.rank) |> Repo.all
+
+    assert ranks == Enum.uniq(ranks)
+  end
+
 end
 
 

--- a/test/ecto_ordered_test.exs
+++ b/test/ecto_ordered_test.exs
@@ -103,6 +103,16 @@ defmodule EctoOrderedTest do
     assert model.rank == model1.rank
   end
 
+  test "moving an item when nothing is ranked" do
+    model1 = %Model{title: "item #1"} |> Repo.insert!
+    model2 = %Model{title: "item #2"} |> Repo.insert!
+
+    model2 |> Model.changeset(%{move: :up}) |> Repo.update!
+
+    Repo.all(Model)
+    assert ranked_ids(Model) == [model2.id, model1.id]
+  end
+
   test "replacing an item below" do
     model1 = Model.changeset(%Model{title: "item #1"}, %{}) |> Repo.insert!
     model2 = Model.changeset(%Model{title: "item #2"}, %{}) |> Repo.insert!

--- a/test/ecto_ordered_test.exs
+++ b/test/ecto_ordered_test.exs
@@ -317,21 +317,21 @@ defmodule EctoOrderedTest.Scoped do
   end
 
   test "scoped: moving between scopes" do
-    model1 = Model.changeset(%Model{scope: 1, title: "item #1"}, %{}) |> Repo.insert!
-    model2 = Model.changeset(%Model{scope: 1, title: "item #2"}, %{}) |> Repo.insert!
-    model3 = Model.changeset(%Model{scope: 1, title: "item #3"}, %{}) |> Repo.insert!
+    scope1_model1 = Model.changeset(%Model{scope: 1, title: "item #1"}, %{}) |> Repo.insert!
+    scope1_model2 = Model.changeset(%Model{scope: 1, title: "item #2"}, %{}) |> Repo.insert!
+    scope1_model3 = Model.changeset(%Model{scope: 1, title: "item #3"}, %{}) |> Repo.insert!
 
-    xmodel1 = Model.changeset(%Model{scope: 2, title: "item #1"}, %{}) |> Repo.insert!
-    xmodel2 = Model.changeset(%Model{scope: 2, title: "item #2"}, %{}) |> Repo.insert!
-    xmodel3 = Model.changeset(%Model{scope: 2, title: "item #3"}, %{}) |> Repo.insert!
+    scope2_model1 = Model.changeset(%Model{scope: 2, title: "item #1"}, %{}) |> Repo.insert!
+    scope2_model2 = Model.changeset(%Model{scope: 2, title: "item #2"}, %{}) |> Repo.insert!
+    scope2_model3 = Model.changeset(%Model{scope: 2, title: "item #3"}, %{}) |> Repo.insert!
 
-    model2 |> Model.changeset(%{scoped_position: 4, scope: 2}) |> Repo.update
+    scope1_model2 |> Model.changeset(%{scoped_position: 4, scope: 2}) |> Repo.update
 
-    assert Repo.get(Model, model1.id).scope == 1
-    assert Repo.get(Model, model3.id).scope == 1
-    assert ranked_ids(Model, 1) == [model1.id, model3.id]
+    assert Repo.get(Model, scope1_model1.id).scope == 1
+    assert Repo.get(Model, scope1_model3.id).scope == 1
+    assert ranked_ids(Model, 1) == [scope1_model1.id, scope1_model3.id]
 
-    assert ranked_ids(Model, 2) == [xmodel1.id, xmodel2.id, xmodel3.id, model2.id]
+    assert ranked_ids(Model, 2) == [scope2_model1.id, scope2_model2.id, scope2_model3.id, scope1_model2.id]
   end
 
   ## Deletion

--- a/test/ecto_ordered_test.exs
+++ b/test/ecto_ordered_test.exs
@@ -206,6 +206,9 @@ defmodule EctoOrderedTest do
 
   test "collision handling at max" do
     for _ <- 1..100 do
+      Model.changeset(%Model{}, %{position: 0}) |> Repo.insert
+    end
+    for _ <- 1..100 do
       Model.changeset(%Model{}, %{}) |> Repo.insert!
     end
 


### PR DESCRIPTION
This is a significant change (okay, it's pretty much a rewrite), but it make things more robust.

A lot of the techniques used here are inspired by [mixonic/ranked-model](https://github.com/mixonic/ranked-model).

Instead of using an explicit position stored against each row, we record an integer which allows the database to order things for us. That means that we have less database churn in many situations. Insertions will more frequently happen without the need for an update of other rows.

This is not yet ready to be merged, because the documentation in README.md and the module and the inline documentation has not been updated. I'd also be keen for some code review before I merge this.
