### PR TITLE
Fix moving an item up

### DIFF
--- a/lib/ecto_ordered.ex
+++ b/lib/ecto_ordered.ex
@@ -133,7 +133,7 @@ defmodule EctoOrdered do
   defp get_previous_two(options, cs) do
     current_rank = get_field(cs, options.rank_field) || @max
     previous = options
-    |> nearby_query(cs)
+    |> nearby_query(cs, :desc)
     |> where([r], field(r, ^options.rank_field) < ^current_rank)
     |> cs.repo.all
     case previous do
@@ -144,7 +144,7 @@ defmodule EctoOrdered do
   end
 
   defp get_next_two(options, cs) do
-    current_rank = get_field(cs, options.rank_field) 
+    current_rank = get_field(cs, options.rank_field)
     next = options
     |> nearby_query(cs)
     |> where([r], field(r, ^options.rank_field) > ^current_rank)
@@ -156,13 +156,14 @@ defmodule EctoOrdered do
     end
   end
 
-  defp nearby_query(options, cs) do
+  defp nearby_query(options, cs, direction \\ :asc) do
     options
     |> rank_query
     |> scope_query(options, cs)
     |> select_rank(options.rank_field)
     |> limit(2)
-    |> order_by(^options.rank_field)
+    |> Ecto.Query.exclude(:order_by)
+    |> order_by({^direction, ^options.rank_field})
   end
 
   defp ensure_unique_position(cs, %Options{rank_field: rank_field} = options) do

--- a/test/ecto_ordered_test.exs
+++ b/test/ecto_ordered_test.exs
@@ -151,10 +151,11 @@ defmodule EctoOrderedTest do
     model1 = Model.changeset(%Model{title: "item #1"}, %{}) |> Repo.insert!
     model2 = Model.changeset(%Model{title: "item #2"}, %{}) |> Repo.insert!
     model3 = Model.changeset(%Model{title: "item #3"}, %{}) |> Repo.insert!
+    model4 = Model.changeset(%Model{title: "item #4"}, %{}) |> Repo.insert!
 
-    model2 |> Model.changeset(%{move: :up}) |> Repo.update!
+    model4 |> Model.changeset(%{move: :up}) |> Repo.update!
 
-    assert ranked_ids(Model) == [model2.id, model1.id, model3.id]
+    assert ranked_ids(Model) == [model1.id, model2.id, model4.id, model3.id]
   end
 
   test "moving an item down using the :down position symbol" do


### PR DESCRIPTION
Because the query to find the two previous items wasn’t sorted in descending order, it would always return the first two items in the list (positions 1 and 2), not the two items immediately before the item we want to move up. For `nearby_query` on an item in the 10th position would return the 1st/2nd items, not the 8th/9th.

The existing test didn't catch this because it was only using a 3-item list. I updated the test with 4 items, moving the 4th item up to make sure it goes between the 2nd/3rd items (instead of the 1st/2nd). Solution was to update the `nearby_query` function to accept an `order_by` direction.