### PR TITLE
Shifting ranks is not properly scoped, causes Postgres errors

### DIFF
--- a/lib/ecto_ordered.ex
+++ b/lib/ecto_ordered.ex
@@ -144,7 +144,7 @@ defmodule EctoOrdered do
   end
 
   defp get_next_two(options, cs) do
-    current_rank = get_field(cs, options.rank_field) 
+    current_rank = get_field(cs, options.rank_field)
     next = options
     |> nearby_query(cs)
     |> where([r], field(r, ^options.rank_field) > ^current_rank)
@@ -239,6 +239,7 @@ defmodule EctoOrdered do
     options.module
     |> where([r], field(r, ^rank_field) >= ^current_rank)
     |> exclude_existing(existing)
+    |> scope_query(options, cs)
     |> cs.repo.update_all([inc: [{rank_field, 1}]])
     cs
   end
@@ -248,6 +249,7 @@ defmodule EctoOrdered do
     options.module
     |> where([r], field(r, ^rank_field) <= ^current_rank)
     |> exclude_existing(existing)
+    |> scope_query(options, cs)
     |> cs.repo.update_all([inc: [{rank_field, -1}]])
     cs
   end


### PR DESCRIPTION
Because the `increment_other_ranks`/`decrement_other_ranks` functions weren't using `scope_query`, shifting ranks in one scope was increasing the ranks in all other scopes.

While this can cause many unnecessary database writes to scopes that shouldn't be affected, the bigger issue is when a different scope has an item ranked at `@max`. Because `get_current_last` is scoped, but `increment_other_ranks` is not, it tries to increase the rank of that item at `@max`, raising an `integer out of range` error in Postgres.